### PR TITLE
VS code auto ended web-app early

### DIFF
--- a/webapp/WEB-INF/web.xml
+++ b/webapp/WEB-INF/web.xml
@@ -4,7 +4,6 @@
   xmlns:web="http://java.sun.com/xml/ns/javaee"
   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
   version="3.0">
-<web-app>
 
   <display-name>nshmp-site-ws</display-name>
 


### PR DESCRIPTION
Visual studio code accidentally added a `<web-app>` ending it early.